### PR TITLE
Clear missiles functionaliity

### DIFF
--- a/menu.go
+++ b/menu.go
@@ -133,7 +133,24 @@ func launchMissile() {
 }
 
 func inventoryReport() {
-	fmt.Println("Inventory report")
+	launcherTypes := orderLaunchers()
+	var totalMissiles int
+
+	t := table.NewWriter()
+
+	t.SetAutoIndex(true)
+	t.AppendHeader(table.Row{"Launcher Type", "Missiles"})
+
+	for _, lt := range launcherTypes {
+		ml := launchers[lt]
+		totalMissiles += ml.len()
+		t.AppendRow(table.Row{lt.String(), ml.len()})
+	}
+
+	t.AppendFooter(table.Row{"Total", totalMissiles})
+	t.SetCaption("Missile Inventory Report")
+
+	fmt.Println(t.Render())
 }
 
 func cleanOutMissiles() {

--- a/menu.go
+++ b/menu.go
@@ -123,7 +123,7 @@ func launchMissile() {
 		}
 
 		if missilesCount > mLauncher.len() {
-			mLauncher.add(missilesCount)
+			mLauncher.add(missilesCount - mLauncher.len())
 		}
 
 		successfulLaunches := mLauncher.launch(missilesCount)

--- a/menu.go
+++ b/menu.go
@@ -153,8 +153,62 @@ func inventoryReport() {
 	fmt.Println(t.Render())
 }
 
-func cleanOutMissiles() {
-	fmt.Println("Clean out missiles")
+func clearMissiles() {
+	const cleanAll = "All"
+	var totalMissiles int
+	r := bufio.NewReader(os.Stdin)
+
+	// Clean out missiles only if the input was not a number
+	for {
+
+		// cleanScreen()
+		// Write to the terminal instread of the user
+		fmt.Printf("To clean out all missiles, type '%s'\n", cleanAll)
+		fmt.Println("To clean out a missile at a specific index, type the index number")
+		fmt.Print("Enter your choice: ")
+		// Write to the teminal so the reader can read it
+
+		input, _ := r.ReadString('\n')
+		input = strings.TrimSpace(input)
+
+		if input == cleanAll {
+			for _, ml := range launchers {
+				ml.clear()
+			}
+
+			fmt.Println("All missiles cleaned out")
+			break
+		}
+
+		indexToRemove, err := convertStringToInt(input)
+		if err != nil {
+			fmt.Println("Invalid input, please try again")
+			continue
+		}
+
+		if indexToRemove < 0 {
+			fmt.Println("Please enter a positive number")
+			continue
+		}
+
+		if indexToRemove == 0 {
+			break
+		}
+
+		// Clean out missiles at a specific index
+		for _, ml := range launchers {
+			if indexToRemove < ml.len() {
+				ml.clearAt(indexToRemove)
+				fmt.Printf("Missile at index %d cleaned out\n", indexToRemove)
+				return
+			}
+
+			totalMissiles += ml.len()
+			indexToRemove -= ml.len()
+		}
+
+		fmt.Printf("Invalid index, we have a total of %d missiles. Please try again\n", totalMissiles)
+	}
 }
 
 func shutdown() {
@@ -177,7 +231,7 @@ var menu map[menuOption]menuItem = map[menuOption]menuItem{
 	},
 	menuCleanOutMissles: {
 		name:   "Clean out missiles",
-		action: cleanOutMissiles,
+		action: clearMissiles,
 	},
 	menuShutdown: {
 		name:   "Shutdown",

--- a/missile.go
+++ b/missile.go
@@ -167,7 +167,7 @@ func initLaunchers() {
 	}
 }
 
-func printMissilesLaunchers() {
+func orderLaunchers() []launcher {
 	var launcherTypes []launcher
 
 	for key := range launchers {
@@ -177,8 +177,14 @@ func printMissilesLaunchers() {
 	// sort the launchers
 	slices.Sort(launcherTypes)
 
-	for i := 0; i < len(launcherTypes); i++ {
-		fmt.Printf("%d. %s\n", i+1, launcherTypes[i])
+	return launcherTypes
+}
+
+func printMissilesLaunchers() {
+	launchers := orderLaunchers()
+
+	for i := 0; i < len(launchers); i++ {
+		fmt.Printf("%d. %s\n", i+1, launchers[i])
 	}
 
 	fmt.Println()

--- a/missile.go
+++ b/missile.go
@@ -51,6 +51,7 @@ type missileLauncher interface {
 	launch(count int) int
 	add(count int)
 	clear()
+	clearAt(index int)
 	len() int
 }
 
@@ -67,6 +68,12 @@ func (m *missileStorage) add(count int) {
 		m.missiles = append(m.missiles, missile{
 			failed: false,
 		})
+	}
+}
+
+func (m *missileStorage) clearAt(index int) {
+	if index < len(m.missiles) && index >= 0 { // Check for valid index
+		m.missiles = append(m.missiles[:index], m.missiles[index+1:]...)
 	}
 }
 

--- a/missile.go
+++ b/missile.go
@@ -5,7 +5,22 @@ import (
 	"fmt"
 	"os"
 	"slices"
+	"sort"
 )
+
+func removeByIndexes(missiles []missile, indexes []int) []missile {
+	// Sort the indexes in descending order
+	sort.Sort(sort.Reverse(sort.IntSlice(indexes)))
+
+	// Remove the elements by index
+	for _, index := range indexes {
+		if index < len(missiles) && index >= 0 { // Check for valid index
+			missiles = append(missiles[:index], missiles[index+1:]...)
+		}
+	}
+
+	return missiles
+}
 
 type launcher int
 
@@ -75,7 +90,8 @@ type torpedoMissileLauncher struct {
 }
 
 func (t *torpedoMissileLauncher) launch(count int) int {
-	successCount := 0
+	launched := 0
+	launchedIndexes := make([]int, 0)
 
 	for i := 0; i < count; i++ {
 		m := t.missiles[i]
@@ -86,13 +102,15 @@ func (t *torpedoMissileLauncher) launch(count int) int {
 
 		missileHitRate := random(0, 100)
 		if missileHitRate < t.successRate {
-			successCount++
+			launched++
+			launchedIndexes = append(launchedIndexes, i)
 		} else {
 			m.failed = true
 		}
 	}
 
-	return successCount
+	t.missiles = removeByIndexes(t.missiles, launchedIndexes)
+	return launched
 }
 
 type ballisticMissileLauncher struct {
@@ -101,7 +119,8 @@ type ballisticMissileLauncher struct {
 }
 
 func (b *ballisticMissileLauncher) launch(count int) int {
-	successCount := 0
+	launched := 0
+	launchedIndexes := make([]int, 0)
 
 	for i := 0; i < count; i++ {
 		m := b.missiles[i]
@@ -111,13 +130,16 @@ func (b *ballisticMissileLauncher) launch(count int) int {
 
 		missileHitRate := random(0, 100)
 		if missileHitRate < b.successRate {
-			successCount++
+			launched++
+			launchedIndexes = append(launchedIndexes, i)
 		} else {
 			m.failed = true
 		}
 	}
 
-	return successCount
+	b.missiles = removeByIndexes(b.missiles, launchedIndexes)
+
+	return launched
 }
 
 type cruiseMissileLauncher struct {
@@ -126,7 +148,8 @@ type cruiseMissileLauncher struct {
 }
 
 func (c *cruiseMissileLauncher) launch(count int) int {
-	successCount := 0
+	launched := 0
+	launchedIndexes := make([]int, 0)
 
 	for i := 0; i < count; i++ {
 		m := c.missiles[i]
@@ -137,13 +160,15 @@ func (c *cruiseMissileLauncher) launch(count int) int {
 
 		missileHitRate := random(0, 100)
 		if missileHitRate < c.successRate {
-			successCount++
+			launched++
+			launchedIndexes = append(launchedIndexes, i)
 		} else {
 			m.failed = true
 		}
 	}
 
-	return successCount
+	c.missiles = removeByIndexes(c.missiles, launchedIndexes)
+	return launched
 }
 
 var launchers = map[launcher]missileLauncher{


### PR DESCRIPTION
Add the last menu action that has not been done - clear missiles.
Add two ways to clear:

1. If the user types 'All' the program clears all the missiles in all the launchers
2. If the user types in a number the program removes the missile at the specific index